### PR TITLE
Hide pointers from the stack public API

### DIFF
--- a/justfile
+++ b/justfile
@@ -31,6 +31,10 @@ cover:
     go tool cover -html={{ COVERAGE_DATA }} -o {{ COVERAGE_HTML }}
     open {{ COVERAGE_HTML }}
 
+# Run the benchmarks
+bench:
+    go test ./... -run=None -benchmem -bench .
+
 # Remove build artifacts and other project clutter
 clean:
     go clean ./...

--- a/stack/stack.go
+++ b/stack/stack.go
@@ -6,22 +6,26 @@ import (
 	"fmt"
 )
 
+// ErrPopFromEmptyStack is returned when Pop() is called on an empty stack.
+var ErrPopFromEmptyStack = errors.New("pop from empty stack")
+
 // Stack is a LIFO stack generic over any type.
 type Stack[T any] struct {
-	container []T // Underlying slice
+	container *[]T // Underlying slice, reference to allow mutation.
 }
 
 // New constructs and returns a new stack.
-func New[T any]() *Stack[T] {
-	return &Stack[T]{container: make([]T, 0)}
+func New[T any]() Stack[T] {
+	container := make([]T, 0)
+	return Stack[T]{container: &container}
 }
 
 // Push adds an item to the top of stack.
 //
 //	s := stack.New[string]()
 //	s.Push("hello")
-func (s *Stack[T]) Push(item T) {
-	s.container = append(s.container, item)
+func (s Stack[T]) Push(item T) {
+	*s.container = append(*s.container, item)
 }
 
 // Pop removes an item from the top of the stack, if the stack
@@ -35,14 +39,14 @@ func (s *Stack[T]) Push(item T) {
 //
 //	item, _ := s.Pop()
 //	fmt.Println(item) // "kenobi"
-func (s *Stack[T]) Pop() (T, error) {
-	l := len(s.container)
+func (s Stack[T]) Pop() (T, error) {
+	l := len(*s.container)
 	if l == 0 {
 		var none T
-		return none, errors.New("pop from empty stack")
+		return none, ErrPopFromEmptyStack
 	}
-	item := s.container[l-1]
-	s.container = s.container[:l-1]
+	item := (*s.container)[l-1]
+	*s.container = (*s.container)[:l-1]
 
 	return item, nil
 }
@@ -53,8 +57,8 @@ func (s *Stack[T]) Pop() (T, error) {
 //	s.Push("hello")
 //	s.Push("there")
 //	s.Length() // 2
-func (s *Stack[T]) Length() int {
-	return len(s.container)
+func (s Stack[T]) Length() int {
+	return len(*s.container)
 }
 
 // IsEmpty returns whether or not the stack is empty.
@@ -63,21 +67,21 @@ func (s *Stack[T]) Length() int {
 //	s.IsEmpty() // true
 //	s.Push("hello")
 //	s.IsEmpty() // false
-func (s *Stack[T]) IsEmpty() bool {
-	return len(s.container) == 0
+func (s Stack[T]) IsEmpty() bool {
+	return len(*s.container) == 0
 }
 
-// Items returns the items in the stack as a slice.
+// Items returns the items in the stack as a new slice (copy).
 //
 //	s := stack.New[string]()
 //	s.Push("hello")
 //	s.Push("there")
 //	s.Items() // [hello there]
-func (s *Stack[T]) Items() []T {
-	return s.container
+func (s Stack[T]) Items() []T {
+	return append([]T{}, *s.container...)
 }
 
 // String satisfies the stringer interface and allows a stack to be printed.
 func (s Stack[T]) String() string {
-	return fmt.Sprintf("%v", s.container)
+	return fmt.Sprintf("%v", *s.container)
 }

--- a/stack/stack_test.go
+++ b/stack/stack_test.go
@@ -76,9 +76,19 @@ func TestPop(t *testing.T) {
 	}
 
 	// Try one more pop, should error
-	_, err = s.Pop()
+	item, err = s.Pop()
 	if err == nil {
 		t.Error("expected pop from empty stack error, got nil")
+	}
+
+	// Err should be a ErrPopFromEmptyStack
+	if err != stack.ErrPopFromEmptyStack {
+		t.Errorf("wrong error returned: got %v, wanted %v", err, stack.ErrPopFromEmptyStack)
+	}
+
+	// Item should be the zero value for the type
+	if item != "" {
+		t.Errorf("empty pop should be zero value: got %q, wanted %q", item, "")
 	}
 }
 

--- a/stack/stack_test.go
+++ b/stack/stack_test.go
@@ -119,3 +119,18 @@ func TestString(t *testing.T) {
 		t.Errorf("wrong string: got %s, wanted %s", s.String(), want)
 	}
 }
+
+func BenchmarkStack(b *testing.B) {
+	s := stack.New[int]()
+
+	for i := 0; i < b.N; i++ {
+		s.Push(i)
+	}
+
+	for i := 0; i < b.N; i++ {
+		_, err := s.Pop()
+		if err != nil {
+			b.Errorf("Pop() returned an error: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
- Remove unneeded pointers from stack
- Add stack push/pop benchmark

<!-- Provide a brief summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->
Tweaked the public API of `stack` such that `stack.New` no longer produces a pointer but an owned `Stack`, backed by
an internal pointer to the underlying slice, but the caller need not know this.

Doing so eliminates all memory allocations in the `stack` package, as evidenced by the included benchmark

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

#### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation if needed.
- [ ] I have updated the tests if needed.
