### PR TITLE
Add notion of capacity/size to collections

### DIFF
--- a/queue/option.go
+++ b/queue/option.go
@@ -1,0 +1,24 @@
+package queue
+
+// options is a struct that holds the options for a queue.
+type options struct {
+	capacity int // The initial capacity of the queue.
+}
+
+// Option is a function that configures a queue.
+type Option func(*options)
+
+// WithCapacity sets the initial capacity of the queue.
+//
+// If the capacity is negative, the default of 0 is used.
+//
+//	q := queue.New[string](queue.WithCapacity(10))
+//	q.Cap() // 10
+func WithCapacity(capacity int) Option {
+	return func(o *options) {
+		// Capacity must be a positive number
+		if capacity > 0 {
+			o.capacity = capacity
+		}
+	}
+}

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -16,13 +16,19 @@ var ErrPopFromEmptyQueue = errors.New("pop from empty queue")
 // A Queue should be instantiated by the New function and not directly,
 // doing so will result in a nil pointer dereference.
 type Queue[T any] struct {
-	container *[]T // Underlying slice
+	container *[]T    // Underlying slice
+	options   options // Options for the queue.
 }
 
 // New constructs and returns a new stack.
-func New[T any]() Queue[T] {
-	container := make([]T, 0) // Initialise the underlying slice
-	return Queue[T]{container: &container}
+func New[T any](options ...Option) Queue[T] {
+	queue := Queue[T]{}
+	for _, option := range options {
+		option(&queue.options)
+	}
+	container := make([]T, 0, queue.options.capacity)
+	queue.container = &container
+	return queue
 }
 
 // Push adds an item to the back of the queue.
@@ -62,6 +68,14 @@ func (q Queue[T]) Pop() (T, error) {
 //	s.Length() // 2
 func (q Queue[T]) Length() int {
 	return len(*q.container)
+}
+
+// Cap returns the current capacity of the queue.
+//
+//	s := queue.New[string](queue.WithCapacity(10))
+//	s.Cap() // 10
+func (q Queue[T]) Cap() int {
+	return cap(*q.container)
 }
 
 // IsEmpty returns whether or not the queue is empty.

--- a/queue/queue_test.go
+++ b/queue/queue_test.go
@@ -36,6 +36,23 @@ func TestLength(t *testing.T) {
 	}
 }
 
+func TestCap(t *testing.T) {
+	s := queue.New[int](queue.WithCapacity(10))
+	if s.Cap() != 10 {
+		t.Errorf("wrong capacity: got %d, wanted %d", s.Cap(), 10)
+	}
+
+	s2 := queue.New[int]()
+	if s2.Cap() != 0 {
+		t.Errorf("wrong capacity: got %d, wanted %d", s2.Cap(), 0)
+	}
+
+	s3 := queue.New[int](queue.WithCapacity(-1))
+	if s3.Cap() != 0 {
+		t.Errorf("wrong capacity: got %d, wanted %d", s3.Cap(), 0)
+	}
+}
+
 func TestPop(t *testing.T) {
 	q := queue.New[string]()
 	q.Push("hello")

--- a/set/option.go
+++ b/set/option.go
@@ -12,10 +12,7 @@ type Option func(*options)
 
 // WithSize sets the starting size of the set.
 //
-// If the size is negative, the default of 10 is used.
-//
-//	s := set.New[string](set.WithSize(10))
-//	s.Cap() // 10
+// If the size is negative or unset, the default of 10 is used.
 func WithSize(size int) Option {
 	return func(o *options) {
 		// Size must be a positive number

--- a/set/option.go
+++ b/set/option.go
@@ -1,0 +1,28 @@
+package set
+
+const defaultMapSize = 10
+
+// options is a struct that holds the options for a set.
+type options struct {
+	size int // The starting size of the set
+}
+
+// Option is a function that configures a set.
+type Option func(*options)
+
+// WithSize sets the starting size of the set.
+//
+// If the size is negative, the default of 10 is used.
+//
+//	s := set.New[string](set.WithSize(10))
+//	s.Cap() // 10
+func WithSize(size int) Option {
+	return func(o *options) {
+		// Size must be a positive number
+		if size > 0 {
+			o.size = size
+		} else {
+			o.size = defaultMapSize
+		}
+	}
+}

--- a/set/set.go
+++ b/set/set.go
@@ -20,12 +20,18 @@ import (
 // doing so will result in a nil pointer dereference.
 type Set[T comparable] struct {
 	container *map[T]struct{} // Underlying map with empty struct for minimal memory use
+	options   options         // Options for the set.
 }
 
 // New constructs and returns a new set for a specific comparable type.
-func New[T comparable]() Set[T] {
-	container := make(map[T]struct{}) // Initialise the underlying map
-	return Set[T]{container: &container}
+func New[T comparable](options ...Option) Set[T] {
+	set := Set[T]{}
+	for _, option := range options {
+		option(&set.options)
+	}
+	container := make(map[T]struct{}, set.options.size)
+	set.container = &container
+	return set
 }
 
 // Add adds an item to the set, if the item is

--- a/set/set_test.go
+++ b/set/set_test.go
@@ -94,6 +94,28 @@ func TestBasics(t *testing.T) {
 	})
 }
 
+func TestWithSize(t *testing.T) {
+	s := set.New[string](set.WithSize(10))
+	s.Add("hello")
+	s.Add("there")
+	s.Add("general")
+	s.Add("kenobi")
+
+	if s.Length() != 4 {
+		t.Errorf("wrong length: got %d, wanted %d", s.Length(), 4)
+	}
+
+	s2 := set.New[string](set.WithSize(-10))
+	s2.Add("hello")
+	s2.Add("there")
+	s2.Add("general")
+	s2.Add("kenobi")
+
+	if s2.Length() != 4 {
+		t.Errorf("wrong length: got %d, wanted %d", s2.Length(), 4)
+	}
+}
+
 func TestUnion(t *testing.T) {
 	this := set.New[string]()
 	that := set.New[string]()

--- a/set/set_test.go
+++ b/set/set_test.go
@@ -105,7 +105,7 @@ func TestWithSize(t *testing.T) {
 		t.Errorf("wrong length: got %d, wanted %d", s.Length(), 4)
 	}
 
-	s2 := set.New[string](set.WithSize(-10))
+	s2 := set.New[string](set.WithSize(-10)) // Shouldn't panic
 	s2.Add("hello")
 	s2.Add("there")
 	s2.Add("general")

--- a/stack/option.go
+++ b/stack/option.go
@@ -1,0 +1,24 @@
+package stack
+
+// options is a struct that holds the options for a stack.
+type options struct {
+	capacity int // The initial capacity of the stack.
+}
+
+// Option is a function that configures a stack.
+type Option func(*options)
+
+// WithCapacity sets the initial capacity of the stack.
+//
+// If the capacity is negative, the default of 0 is used.
+//
+//	s := stack.New[string](stack.WithCapacity(10))
+//	s.Cap() // 10
+func WithCapacity(capacity int) Option {
+	return func(o *options) {
+		// Capacity must be a positive number
+		if capacity > 0 {
+			o.capacity = capacity
+		}
+	}
+}

--- a/stack/stack.go
+++ b/stack/stack.go
@@ -16,13 +16,19 @@ var ErrPopFromEmptyStack = errors.New("pop from empty stack")
 // A Stack should be instantiated by the New function and not directly,
 // doing so will result in a nil pointer dereference.
 type Stack[T any] struct {
-	container *[]T // Underlying slice, reference to allow mutation.
+	container *[]T    // Underlying slice, reference to allow mutation.
+	options   options // Options for the stack.
 }
 
 // New constructs and returns a new stack.
-func New[T any]() Stack[T] {
-	container := make([]T, 0)
-	return Stack[T]{container: &container}
+func New[T any](options ...Option) Stack[T] {
+	stack := Stack[T]{}
+	for _, option := range options {
+		option(&stack.options)
+	}
+	container := make([]T, 0, stack.options.capacity)
+	stack.container = &container
+	return stack
 }
 
 // Push adds an item to the top of stack.
@@ -64,6 +70,14 @@ func (s Stack[T]) Pop() (T, error) {
 //	s.Length() // 2
 func (s Stack[T]) Length() int {
 	return len(*s.container)
+}
+
+// Cap returns the current capacity of the stack.
+//
+//	s := stack.New[string](stack.WithCapacity(10))
+//	s.Cap() // 10
+func (s Stack[T]) Cap() int {
+	return cap(*s.container)
 }
 
 // IsEmpty returns whether or not the stack is empty.

--- a/stack/stack_test.go
+++ b/stack/stack_test.go
@@ -36,6 +36,23 @@ func TestLength(t *testing.T) {
 	}
 }
 
+func TestCap(t *testing.T) {
+	s := stack.New[int](stack.WithCapacity(10))
+	if s.Cap() != 10 {
+		t.Errorf("wrong capacity: got %d, wanted %d", s.Cap(), 10)
+	}
+
+	s2 := stack.New[int]()
+	if s2.Cap() != 0 {
+		t.Errorf("wrong capacity: got %d, wanted %d", s2.Cap(), 0)
+	}
+
+	s3 := stack.New[int](stack.WithCapacity(-1))
+	if s3.Cap() != 0 {
+		t.Errorf("wrong capacity: got %d, wanted %d", s3.Cap(), 0)
+	}
+}
+
 func TestPop(t *testing.T) {
 	s := stack.New[string]()
 	s.Push("hello")


### PR DESCRIPTION
<!-- Provide a brief summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->
Adds the notion of setting a capacity or size to the collections in this package, also implemented
a functional options API e.g. `stack.WithCapacity(10)` to make configuration easier.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

#### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation if needed.
- [ ] I have updated the tests if needed.
