### PR TITLE
Simplify the stack API

### DIFF
--- a/stack/option.go
+++ b/stack/option.go
@@ -10,7 +10,8 @@ type Option func(*options)
 
 // WithCapacity sets the initial capacity of the stack.
 //
-// If the capacity is negative, the default of 0 is used.
+// If the capacity is negative, the default of 0 is used which is equivalent to
+// the capacity go allocates new slices.
 //
 //	s := stack.New[string](stack.WithCapacity(10))
 //	s.Cap() // 10

--- a/stack/stack.go
+++ b/stack/stack.go
@@ -1,6 +1,6 @@
 // Package stack implements a LIFO stack generic over any type.
 //
-// The stack is implemented using an internal slice pointer, and is not thread safe.
+// The stack is not safe for concurrent access by default, the caller must synchronise access.
 package stack
 
 import (
@@ -13,30 +13,29 @@ var ErrPopFromEmptyStack = errors.New("pop from empty stack")
 
 // Stack is a LIFO stack generic over any type.
 //
-// A Stack should be instantiated by the New function and not directly,
-// doing so will result in a nil pointer dereference.
+// A Stack should be instantiated by the New function and not directly.
 type Stack[T any] struct {
-	container *[]T    // Underlying slice, reference to allow mutation.
+	container []T     // Underlying slice, reference to allow mutation.
 	options   options // Options for the stack.
 }
 
 // New constructs and returns a new stack.
-func New[T any](options ...Option) Stack[T] {
+func New[T any](options ...Option) *Stack[T] {
 	stack := Stack[T]{}
 	for _, option := range options {
 		option(&stack.options)
 	}
 	container := make([]T, 0, stack.options.capacity)
-	stack.container = &container
-	return stack
+	stack.container = container
+	return &stack
 }
 
 // Push adds an item to the top of stack.
 //
 //	s := stack.New[string]()
 //	s.Push("hello")
-func (s Stack[T]) Push(item T) {
-	*s.container = append(*s.container, item)
+func (s *Stack[T]) Push(item T) {
+	s.container = append(s.container, item)
 }
 
 // Pop removes an item from the top of the stack, if the stack
@@ -50,14 +49,14 @@ func (s Stack[T]) Push(item T) {
 //
 //	item, _ := s.Pop()
 //	fmt.Println(item) // "kenobi"
-func (s Stack[T]) Pop() (T, error) {
-	l := len(*s.container)
+func (s *Stack[T]) Pop() (T, error) {
+	l := len(s.container)
 	if l == 0 {
 		var none T
 		return none, ErrPopFromEmptyStack
 	}
-	item := (*s.container)[l-1]
-	*s.container = (*s.container)[:l-1]
+	item := s.container[l-1]
+	s.container = s.container[:l-1]
 
 	return item, nil
 }
@@ -68,16 +67,16 @@ func (s Stack[T]) Pop() (T, error) {
 //	s.Push("hello")
 //	s.Push("there")
 //	s.Length() // 2
-func (s Stack[T]) Length() int {
-	return len(*s.container)
+func (s *Stack[T]) Length() int {
+	return len(s.container)
 }
 
 // Cap returns the current capacity of the stack.
 //
 //	s := stack.New[string](stack.WithCapacity(10))
 //	s.Cap() // 10
-func (s Stack[T]) Cap() int {
-	return cap(*s.container)
+func (s *Stack[T]) Cap() int {
+	return cap(s.container)
 }
 
 // IsEmpty returns whether or not the stack is empty.
@@ -86,8 +85,8 @@ func (s Stack[T]) Cap() int {
 //	s.IsEmpty() // true
 //	s.Push("hello")
 //	s.IsEmpty() // false
-func (s Stack[T]) IsEmpty() bool {
-	return len(*s.container) == 0
+func (s *Stack[T]) IsEmpty() bool {
+	return len(s.container) == 0
 }
 
 // Items returns the items in the stack as a new slice (copy).
@@ -96,11 +95,11 @@ func (s Stack[T]) IsEmpty() bool {
 //	s.Push("hello")
 //	s.Push("there")
 //	s.Items() // [hello there]
-func (s Stack[T]) Items() []T {
-	return append([]T{}, *s.container...)
+func (s *Stack[T]) Items() []T {
+	return append([]T{}, s.container...)
 }
 
 // String satisfies the stringer interface and allows a stack to be printed.
-func (s Stack[T]) String() string {
-	return fmt.Sprintf("%v", *s.container)
+func (s *Stack[T]) String() string {
+	return fmt.Sprintf("%v", s.container)
 }

--- a/stack/stack_test.go
+++ b/stack/stack_test.go
@@ -137,6 +137,21 @@ func TestString(t *testing.T) {
 	}
 }
 
+func TestNotNew(t *testing.T) {
+	s := stack.Stack[int]{}
+	s.Push(1)
+	s.Push(2)
+
+	first, err := s.Pop()
+	if err != nil {
+		t.Fatalf("stack.Pop() returned an unexpected error: %v", err)
+	}
+
+	if first != 2 {
+		t.Errorf("wrong item popped: got %d, wanted %d", first, 2)
+	}
+}
+
 func BenchmarkStack(b *testing.B) {
 	s := stack.New[int]()
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->
Simplify the public API for `Stack`, `New` now returns a pointer, the internal container is no longer a pointer and therefore
this eliminates the risk of a user accidentally nil pointer dereferencing themselves if they didn't use `New`.

Also added a test than confirms this.

The plan is to do this for all collections

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

#### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation if needed.
- [ ] I have updated the tests if needed.
