### PR TITLE
Remove interim slice in `IsDisjoint`

### DIFF
--- a/set/set.go
+++ b/set/set.go
@@ -157,6 +157,8 @@ func (s *Set[T]) String() string {
 
 // Equal returns whether two sets are equal to one another, i.e. they are exactly
 // the same size and contain exactly the same elements.
+//
+// If either of the two sets are nil, Equal returns false.
 func Equal[T comparable](a, b *Set[T]) bool {
 	if a == nil || b == nil {
 		return false
@@ -298,13 +300,13 @@ func IsDisjoint[T comparable](sets ...*Set[T]) bool {
 
 	smallest := sets[smallestIndex]
 
-	// Remove the smallest one so we're left with a list of "others"
-	// otherwise disjoint will always be false as the smallest set
-	// will, by definition, include the value and will be included in sets
-	sets = slices.Delete(sets, smallestIndex, smallestIndex+1)
-
 	for item := range smallest.container {
-		for _, other := range sets {
+		for index, other := range sets {
+			// Skip over the smallest one because there's no point comparing
+			// against itself
+			if index == smallestIndex {
+				continue
+			}
 			if other.Contains(item) {
 				return false
 			}


### PR DESCRIPTION
## Summary

<!-- Describe your changes in detail here, if it closes an open issue, include "Closes #<issue>" -->

Remove the need for an interim slice in `IsDisjoint` for about a 10% performance improvement

```plaintext
goos: darwin
goarch: amd64
pkg: github.com/FollowTheProcess/collections/set
cpu: Intel(R) Core(TM) i5-8257U CPU @ 1.40GHz
               │  before.txt  │              after.txt              │
               │    sec/op    │   sec/op     vs base                │
Intersection-8    74.51µ ± 1%   74.62µ ± 1%        ~ (p=0.832 n=30)
Insert-8          73.39µ ± 1%   73.47µ ± 0%        ~ (p=0.663 n=30)
Union-8           116.0µ ± 1%   116.5µ ± 1%        ~ (p=0.854 n=30)
Difference-8      63.52µ ± 1%   63.86µ ± 1%        ~ (p=0.197 n=30)
IsDisjoint-8     105.05n ± 1%   94.44n ± 1%  -10.10% (p=0.000 n=30)
geomean           21.15µ        20.75µ        -1.86%

               │   before.txt   │               after.txt               │
               │      B/op      │     B/op      vs base                 │
Intersection-8   23.46Ki ± 0%     23.46Ki ± 0%       ~ (p=0.947 n=30)
Insert-8         46.62Ki ± 0%     46.62Ki ± 0%       ~ (p=0.806 n=30)
Union-8          48.92Ki ± 0%     48.92Ki ± 0%       ~ (p=0.739 n=30)
Difference-8     23.46Ki ± 0%     23.46Ki ± 0%       ~ (p=0.089 n=30)
IsDisjoint-8       0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=30) ¹
geomean                       ²                 +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

               │  before.txt  │              after.txt              │
               │  allocs/op   │ allocs/op   vs base                 │
Intersection-8   40.00 ± 0%     40.00 ± 0%       ~ (p=1.000 n=30) ¹
Insert-8         65.00 ± 0%     65.00 ± 0%       ~ (p=1.000 n=30) ¹
Union-8          88.00 ± 0%     88.00 ± 0%       ~ (p=1.000 n=30) ¹
Difference-8     40.00 ± 0%     40.00 ± 0%       ~ (p=1.000 n=30) ¹
IsDisjoint-8     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=30) ¹
geomean                     ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```
