### PR TITLE
Optimise `SymmetricDifference`

### DIFF
--- a/set/set.go
+++ b/set/set.go
@@ -292,32 +292,24 @@ func SymmetricDifference[T comparable](a, b *Set[T]) *Set[T] {
 		return a
 	}
 
+	result := New[T]()
+
 	// Simplified version of Difference for performance optimisation
-	uniqueToA := New[T]()
+	// add all the items unique to a
 	for item := range a.container {
 		if !b.Contains(item) {
-			uniqueToA.container[item] = struct{}{}
+			result.container[item] = struct{}{}
 		}
 	}
 
-	uniqueToB := New[T]()
+	// and all the items unique to b
 	for item := range b.container {
 		if !a.Contains(item) {
-			uniqueToB.container[item] = struct{}{}
+			result.container[item] = struct{}{}
 		}
 	}
 
-	union := WithCapacity[T](uniqueToA.Size() + uniqueToB.Size()) // Preallocate the required size
-
-	for item := range uniqueToA.container {
-		union.container[item] = struct{}{}
-	}
-
-	for item := range uniqueToB.container {
-		union.container[item] = struct{}{}
-	}
-
-	return union
+	return result
 }
 
 // IsDisjoint returns whether the sets have no items in common with one another.

--- a/set/set.go
+++ b/set/set.go
@@ -292,9 +292,20 @@ func SymmetricDifference[T comparable](a, b *Set[T]) *Set[T] {
 		return a
 	}
 
-	result := New[T]()
+	// Good balanced approximation for the maximum size of the symmetric difference, if we
+	// allocate enough space for a.Size() + b.Size(), this could explode in the pathological case
+	// and would result in a lot of wasted memory in most normal cases as it would assume each
+	// set is totally unique which is unlikely in the real world.
+	//
+	// Our approximation here is that most real sets contain a mix of unique and non-unique items
+	// and a good guess is that the max of the two sizes should be enough to contain most results
+	// with minimal reallocation.
+	//
+	// This was backed up with benchmarking when I wrote this, without this optimisation we had many
+	// more allocations and it was significantly slower, and a.Size() + b.Size() didn't materially
+	// drop it further, so the below represents what I think is a good compromise of time vs space
+	result := WithCapacity[T](max(a.Size(), b.Size()))
 
-	// Simplified version of Difference for performance optimisation
 	// add all the items unique to a
 	for item := range a.container {
 		if !b.Contains(item) {

--- a/set/set.go
+++ b/set/set.go
@@ -292,10 +292,22 @@ func SymmetricDifference[T comparable](a, b *Set[T]) *Set[T] {
 		return a
 	}
 
-	uniqueToA := Difference(a, b)
-	uniqueToB := Difference(b, a)
+	// Simplified version of Difference for performance optimisation
+	uniqueToA := New[T]()
+	for item := range a.container {
+		if !b.Contains(item) {
+			uniqueToA.container[item] = struct{}{}
+		}
+	}
 
-	union := WithCapacity[T](a.Size() + b.Size()) // Preallocate the required size
+	uniqueToB := New[T]()
+	for item := range b.container {
+		if !a.Contains(item) {
+			uniqueToB.container[item] = struct{}{}
+		}
+	}
+
+	union := WithCapacity[T](uniqueToA.Size() + uniqueToB.Size()) // Preallocate the required size
 
 	for item := range uniqueToA.container {
 		union.container[item] = struct{}{}

--- a/set/set.go
+++ b/set/set.go
@@ -295,7 +295,17 @@ func SymmetricDifference[T comparable](a, b *Set[T]) *Set[T] {
 	uniqueToA := Difference(a, b)
 	uniqueToB := Difference(b, a)
 
-	return Union(uniqueToA, uniqueToB)
+	union := WithCapacity[T](a.Size() + b.Size()) // Preallocate the required size
+
+	for item := range uniqueToA.container {
+		union.container[item] = struct{}{}
+	}
+
+	for item := range uniqueToB.container {
+		union.container[item] = struct{}{}
+	}
+
+	return union
 }
 
 // IsDisjoint returns whether the sets have no items in common with one another.


### PR DESCRIPTION
## Summary

<!-- Describe your changes in detail here, if it closes an open issue, include "Closes #<issue>" -->
Bunch of optimisations of `set.SymmetricDifference` from the somewhat naive first implementation, results in a very significant performance improvement:

```plaintext
goos: darwin
goarch: amd64
pkg: github.com/FollowTheProcess/collections/set
cpu: Intel(R) Core(TM) i5-8257U CPU @ 1.40GHz
                      │  before.txt  │              after.txt              │
                      │    sec/op    │   sec/op     vs base                │
SymmetricDifference-8   208.18µ ± 1%   85.84µ ± 0%  -58.77% (p=0.000 n=30)

                      │  before.txt  │              after.txt               │
                      │     B/op     │     B/op      vs base                │
SymmetricDifference-8   93.67Ki ± 0%   21.44Ki ± 0%  -77.11% (p=0.000 n=30)

                      │  before.txt  │             after.txt              │
                      │  allocs/op   │ allocs/op   vs base                │
SymmetricDifference-8   150.000 ± 0%   8.000 ± 0%  -94.67% (p=0.000 n=30)
```
