### PR TITLE
Fix issue where node is returned from Insert despite not being put into the list

### DIFF
--- a/chain/chain_test.go
+++ b/chain/chain_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestNew(t *testing.T) {
 	chain := chain.New[int, string]()
-	test.Equal(t, chain.Size(), 0) // Wrong chain size before
+	test.Equal(t, chain.Size(), 0, test.Context("Wrong chain size before"))
 }
 
 func TestFrom(t *testing.T) {
@@ -21,7 +21,7 @@ func TestFrom(t *testing.T) {
 	}
 
 	chain := chain.From(maps)
-	test.Equal(t, chain.Size(), 3) // Wrong size (From)
+	test.Equal(t, chain.Size(), 3, test.Context("Wrong size (From)"))
 }
 
 func TestCollect(t *testing.T) {
@@ -32,7 +32,7 @@ func TestCollect(t *testing.T) {
 	}
 
 	chain := chain.Collect(slices.Values(maps))
-	test.Equal(t, chain.Size(), 3) // Wrong size (Collect)
+	test.Equal(t, chain.Size(), 3, test.Context("Wrong size (Collect)"))
 }
 
 func TestAppendGet(t *testing.T) {
@@ -57,7 +57,7 @@ func TestAppendGet(t *testing.T) {
 
 	chain.Append(one)
 
-	test.Equal(t, chain.Size(), 1) // Wrong chain size after append
+	test.Equal(t, chain.Size(), 1, test.Context("Wrong chain size after append"))
 
 	got, ok := chain.Get(1)
 	test.True(t, ok)
@@ -67,15 +67,15 @@ func TestAppendGet(t *testing.T) {
 
 	got, ok = chain.Get(1)
 	test.True(t, ok)
-	test.Equal(t, got, "one in first map") // Higher priority
+	test.Equal(t, got, "one in first map", test.Context("Higher priority"))
 
 	got, ok = chain.Get(2)
 	test.True(t, ok)
-	test.Equal(t, got, "two in first map") // Two is in higher priority map
+	test.Equal(t, got, "two in first map", test.Context("Two is in higher priority map"))
 
 	got, ok = chain.Get(3)
 	test.True(t, ok)
-	test.Equal(t, got, "three in second map") // Three is in second map
+	test.Equal(t, got, "three in second map", test.Context("Three is in second map"))
 
 	chain.Append(three)
 
@@ -85,10 +85,10 @@ func TestAppendGet(t *testing.T) {
 
 	got, ok = chain.Get(4)
 	test.True(t, ok)
-	test.Equal(t, got, "four in third map") // Four only exists in 3rd map
+	test.Equal(t, got, "four in third map", test.Context("Four only exists in 3rd map"))
 
 	got, ok = chain.Get(5)
-	test.False(t, ok) // There is no 5
+	test.False(t, ok, test.Context("There is no 5"))
 	test.Equal(t, got, "")
 }
 
@@ -114,7 +114,7 @@ func TestPrependGet(t *testing.T) {
 
 	chain.Prepend(one)
 
-	test.Equal(t, chain.Size(), 1) // Wrong chain size after prepend
+	test.Equal(t, chain.Size(), 1, test.Context("Wrong chain size after prepend"))
 
 	got, ok := chain.Get(1)
 	test.True(t, ok)
@@ -124,28 +124,28 @@ func TestPrependGet(t *testing.T) {
 
 	got, ok = chain.Get(1)
 	test.True(t, ok)
-	test.Equal(t, got, "one in second map") // Prepended has higher priority
+	test.Equal(t, got, "one in second map", test.Context("Prepended has higher priority"))
 
 	got, ok = chain.Get(2)
 	test.True(t, ok)
-	test.Equal(t, got, "two in second map") // Two is in higher priority map
+	test.Equal(t, got, "two in second map", test.Context("Two is in higher priority map"))
 
 	got, ok = chain.Get(3)
 	test.True(t, ok)
-	test.Equal(t, got, "three in second map") // Three is in second map
+	test.Equal(t, got, "three in second map", test.Context("Three is in second map"))
 
 	chain.Prepend(three)
 
 	got, ok = chain.Get(1)
 	test.True(t, ok)
-	test.Equal(t, got, "one in third map") // Third map is now highest priority
+	test.Equal(t, got, "one in third map", test.Context("Third map is now highest priority"))
 
 	got, ok = chain.Get(4)
 	test.True(t, ok)
-	test.Equal(t, got, "four in third map") // Four only exists in 3rd map
+	test.Equal(t, got, "four in third map", test.Context("Four only exists in 3rd map"))
 
 	got, ok = chain.Get(5)
-	test.False(t, ok) // There is no 5
+	test.False(t, ok, test.Context("There is no 5"))
 	test.Equal(t, got, "")
 }
 
@@ -171,8 +171,8 @@ func TestInsert(t *testing.T) {
 	chain := chain.From(maps)
 
 	got, existed := chain.Insert(1, "updated one in first map")
-	test.True(t, existed)                  // 1 exists in first map
-	test.Equal(t, got, "one in first map") // Returned value should be the old value
+	test.True(t, existed, test.Context("1 exists in first map"))
+	test.Equal(t, got, "one in first map", test.Context("Returned value should be the old value"))
 
 	// If we get it now we should get the updated one
 	got, ok := chain.Get(1)
@@ -237,19 +237,19 @@ func TestRemove(t *testing.T) {
 
 	got, existed := chain.Remove(1)
 	test.True(t, existed)
-	test.Equal(t, got, "one in first map") // Remove should remove 1 from the first map
+	test.Equal(t, got, "one in first map", test.Context("Remove should remove 1 from the first map"))
 
 	got, existed = chain.Remove(1)
 	test.True(t, existed)
-	test.Equal(t, got, "one in second map") // Now the second map
+	test.Equal(t, got, "one in second map", test.Context("Now the second map"))
 
 	got, existed = chain.Remove(1)
 	test.True(t, existed)
-	test.Equal(t, got, "one in third map") // Now the third map
+	test.Equal(t, got, "one in third map", test.Context("Now the third map"))
 
 	got, existed = chain.Remove(1)
 	test.False(t, existed)
-	test.Equal(t, got, "") // No more 1's left
+	test.Equal(t, got, "", test.Context("No more 1's left"))
 
 	got, existed = chain.Get(1)
 	test.False(t, existed)

--- a/counter/counter_test.go
+++ b/counter/counter_test.go
@@ -12,19 +12,19 @@ import (
 func TestNewCounter(t *testing.T) {
 	c := counter.New[string]()
 
-	test.Equal(t, c.Size(), 0) // Initial size must be empty
+	test.Equal(t, c.Size(), 0, test.Context("Initial size must be empty"))
 
-	test.Equal(t, c.Add("apple"), 1) // First add returns 1
-	test.Equal(t, c.Add("apple"), 2) // Second add returns 2
+	test.Equal(t, c.Add("apple"), 1, test.Context("First add returns 1"))
+	test.Equal(t, c.Add("apple"), 2, test.Context("Second add returns 2"))
 
-	test.Equal(t, c.Size(), 1) // "apple" should be the only item
+	test.Equal(t, c.Size(), 1, test.Context("\"apple\" should be the only item"))
 
-	test.Equal(t, c.Add("orange"), 1) // First add returns 1 (orange)
+	test.Equal(t, c.Add("orange"), 1, test.Context("First add returns 1 (orange)"))
 
-	test.Equal(t, c.Size(), 2) // should now have 2 items
+	test.Equal(t, c.Size(), 2, test.Context("should now have 2 items"))
 
-	test.Equal(t, c.Sub("orange"), 0) // Sub("orange") should remove orange completely
-	test.Equal(t, c.Sub("apple"), 1)  // Sub("apple") should decrement apple to 1
+	test.Equal(t, c.Sub("orange"), 0, test.Context("Sub(\"orange\") should remove orange completely"))
+	test.Equal(t, c.Sub("apple"), 1, test.Context("Sub(\"apple\") should decrement apple to 1"))
 }
 
 func TestCount(t *testing.T) {
@@ -34,9 +34,9 @@ func TestCount(t *testing.T) {
 	c.Add("human")
 	c.Add("dog")
 
-	test.Equal(t, c.Get("human"), 2) // Wrong number of humans
-	test.Equal(t, c.Get("dog"), 1)   // Wrong number of dogs
-	test.Equal(t, c.Get("cats"), 0)  // No cats in the counter
+	test.Equal(t, c.Get("human"), 2, test.Context("Wrong number of humans"))
+	test.Equal(t, c.Get("dog"), 1, test.Context("Wrong number of dogs"))
+	test.Equal(t, c.Get("cats"), 0, test.Context("No cats in the counter"))
 }
 
 func TestFrom(t *testing.T) {
@@ -44,15 +44,15 @@ func TestFrom(t *testing.T) {
 
 	c := counter.From(items)
 
-	test.Equal(t, c.Size(), 8)  // Wrong size
-	test.Equal(t, c.Get(1), 1)  // Wrong number of 1s
-	test.Equal(t, c.Get(2), 2)  // Wrong number of 2s
-	test.Equal(t, c.Get(3), 1)  // Wrong number of 4s
-	test.Equal(t, c.Get(4), 3)  // Wrong number of 4s
-	test.Equal(t, c.Get(5), 2)  // Wrong number of 5s
-	test.Equal(t, c.Get(6), 1)  // Wrong number of 6s
-	test.Equal(t, c.Get(8), 1)  // Wrong number of 8s
-	test.Equal(t, c.Get(12), 1) // Wrong number of 12s
+	test.Equal(t, c.Size(), 8, test.Context("Wrong size"))
+	test.Equal(t, c.Get(1), 1, test.Context("Wrong number of 1s"))
+	test.Equal(t, c.Get(2), 2, test.Context("Wrong number of 2s"))
+	test.Equal(t, c.Get(3), 1, test.Context("Wrong number of 4s"))
+	test.Equal(t, c.Get(4), 3, test.Context("Wrong number of 4s"))
+	test.Equal(t, c.Get(5), 2, test.Context("Wrong number of 5s"))
+	test.Equal(t, c.Get(6), 1, test.Context("Wrong number of 6s"))
+	test.Equal(t, c.Get(8), 1, test.Context("Wrong number of 8s"))
+	test.Equal(t, c.Get(12), 1, test.Context("Wrong number of 12s"))
 }
 
 func TestCollect(t *testing.T) {
@@ -60,15 +60,15 @@ func TestCollect(t *testing.T) {
 
 	c := counter.Collect(slices.Values(items))
 
-	test.Equal(t, c.Size(), 8)  // Wrong size
-	test.Equal(t, c.Get(1), 1)  // Wrong number of 1s
-	test.Equal(t, c.Get(2), 2)  // Wrong number of 2s
-	test.Equal(t, c.Get(3), 1)  // Wrong number of 4s
-	test.Equal(t, c.Get(4), 3)  // Wrong number of 4s
-	test.Equal(t, c.Get(5), 2)  // Wrong number of 5s
-	test.Equal(t, c.Get(6), 1)  // Wrong number of 6s
-	test.Equal(t, c.Get(8), 1)  // Wrong number of 8s
-	test.Equal(t, c.Get(12), 1) // Wrong number of 12s
+	test.Equal(t, c.Size(), 8, test.Context("Wrong size"))
+	test.Equal(t, c.Get(1), 1, test.Context("Wrong number of 1s"))
+	test.Equal(t, c.Get(2), 2, test.Context("Wrong number of 2s"))
+	test.Equal(t, c.Get(3), 1, test.Context("Wrong number of 4s"))
+	test.Equal(t, c.Get(4), 3, test.Context("Wrong number of 4s"))
+	test.Equal(t, c.Get(5), 2, test.Context("Wrong number of 5s"))
+	test.Equal(t, c.Get(6), 1, test.Context("Wrong number of 6s"))
+	test.Equal(t, c.Get(8), 1, test.Context("Wrong number of 8s"))
+	test.Equal(t, c.Get(12), 1, test.Context("Wrong number of 12s"))
 }
 
 func TestRemove(t *testing.T) {
@@ -88,12 +88,12 @@ func TestRemove(t *testing.T) {
 
 	tom := person{name: "Tom", age: 30}
 
-	test.Equal(t, c.Size(), 3) // Wrong size
+	test.Equal(t, c.Size(), 3, test.Context("Wrong size"))
 
-	test.Equal(t, c.Remove(tom), 2) // Wrong number of Toms before remove
-	test.Equal(t, c.Get(tom), 0)    // Wrong number of Toms after remove
+	test.Equal(t, c.Remove(tom), 2, test.Context("Wrong number of Toms before remove"))
+	test.Equal(t, c.Get(tom), 0, test.Context("Wrong number of Toms after remove"))
 
-	test.Equal(t, c.Remove(person{name: "missing", age: 35}), 0) // Missing person returns 0
+	test.Equal(t, c.Remove(person{name: "missing", age: 35}), 0, test.Context("Missing person returns 0"))
 }
 
 func TestSum(t *testing.T) {
@@ -131,13 +131,13 @@ func TestReset(t *testing.T) {
 
 	c := counter.From(fruits)
 
-	test.Equal(t, c.Size(), 7)          // Wrong size before Reset
-	test.Equal(t, c.Sum(), len(fruits)) // Wrong sum before Reset
+	test.Equal(t, c.Size(), 7, test.Context("Wrong size before Reset"))
+	test.Equal(t, c.Sum(), len(fruits), test.Context("Wrong sum before Reset"))
 
 	c.Reset()
 
-	test.Equal(t, c.Size(), 0) // Wrong size after Reset
-	test.Equal(t, c.Sum(), 0)  // Wrong sum after Reset
+	test.Equal(t, c.Size(), 0, test.Context("Wrong size after Reset"))
+	test.Equal(t, c.Sum(), 0, test.Context("Wrong sum after Reset"))
 }
 
 func TestDescending(t *testing.T) {

--- a/list/list.go
+++ b/list/list.go
@@ -44,16 +44,13 @@ func New[T any]() *List[T] {
 // Append adds an item to the end (tail) of the list, returning the list [Node] it was inserted into.
 // It may be retrieved afterwards with l.Last().
 func (l *List[T]) Append(item T) *Node[T] {
-	node := NewNode(item)
 	if l.last != nil {
-		// List has items in it, insert after last
+		node := NewNode(item)
 		l.insertAfter(l.last, node)
-	} else {
-		// Empty list
-		l.Prepend(item)
+		return node
 	}
 
-	return node
+	return l.Prepend(item)
 }
 
 // Prepend adds an item to the front (head) of the list, returning the list [Node] it was inserted into.

--- a/list/list_test.go
+++ b/list/list_test.go
@@ -13,11 +13,11 @@ func TestEmptyList(t *testing.T) {
 		list := list.New[string]()
 
 		first, err := list.First()
-		test.Err(t, err) // Should be list is empty error
+		test.Err(t, err, test.Context("Should be list is empty error"))
 		test.Equal(t, first, nil)
 
 		last, err := list.Last()
-		test.Err(t, err) // Should be list is empty error
+		test.Err(t, err, test.Context("Should be list is empty error"))
 		test.Equal(t, last, nil)
 
 		test.Equal(t, list.Len(), 0)
@@ -27,11 +27,11 @@ func TestEmptyList(t *testing.T) {
 		list := &list.List[string]{}
 
 		first, err := list.First()
-		test.Err(t, err) // Should be list is empty error
+		test.Err(t, err, test.Context("Should be list is empty error"))
 		test.Equal(t, first, nil)
 
 		last, err := list.Last()
-		test.Err(t, err) // Should be list is empty error
+		test.Err(t, err, test.Context("Should be list is empty error"))
 		test.Equal(t, last, nil)
 
 		test.Equal(t, list.Len(), 0)
@@ -42,15 +42,15 @@ func TestAppend(t *testing.T) {
 	list := list.New[string]()
 
 	list.Append("foo")
-	test.Equal(t, list.Len(), 1) // Wrong length after append
+	test.Equal(t, list.Len(), 1, test.Context("Wrong length after append"))
 
 	first, err := list.First()
 	test.Ok(t, err)
-	test.Equal(t, first.Item(), "foo") // First item should be "foo"
+	test.Equal(t, first.Item(), "foo", test.Context("First item should be \"foo\""))
 
 	last, err := list.Last()
 	test.Ok(t, err)
-	test.Equal(t, last.Item(), "foo") // Last item should also be "foo"
+	test.Equal(t, last.Item(), "foo", test.Context("Last item should also be \"foo\""))
 
 	// Append again
 	list.Append("bar")
@@ -58,11 +58,11 @@ func TestAppend(t *testing.T) {
 
 	first, err = list.First()
 	test.Ok(t, err)
-	test.Equal(t, first.Item(), "foo") // First should *still* be "foo"
+	test.Equal(t, first.Item(), "foo", test.Context("First should *still* be \"foo\""))
 
 	last, err = list.Last()
 	test.Ok(t, err)
-	test.Equal(t, last.Item(), "bar") // Last should now be "bar"
+	test.Equal(t, last.Item(), "bar", test.Context("Last should now be \"bar\""))
 
 	// One more time
 	list.Append("baz")
@@ -70,26 +70,26 @@ func TestAppend(t *testing.T) {
 
 	first, err = list.First()
 	test.Ok(t, err)
-	test.Equal(t, first.Item(), "foo") // First should *still* be "foo"
+	test.Equal(t, first.Item(), "foo", test.Context("First should *still* be \"foo\""))
 
 	last, err = list.Last()
 	test.Ok(t, err)
-	test.Equal(t, last.Item(), "baz") // Last should now be "baz"
+	test.Equal(t, last.Item(), "baz", test.Context("Last should now be \"baz\""))
 }
 
 func TestPrepend(t *testing.T) {
 	list := list.New[string]()
 
 	list.Prepend("foo")
-	test.Equal(t, list.Len(), 1) // Wrong length after prepend
+	test.Equal(t, list.Len(), 1, test.Context("Wrong length after prepend"))
 
 	first, err := list.First()
 	test.Ok(t, err)
-	test.Equal(t, first.Item(), "foo") // First element should be "foo"
+	test.Equal(t, first.Item(), "foo", test.Context("First element should be \"foo\""))
 
 	last, err := list.Last()
 	test.Ok(t, err)
-	test.Equal(t, last.Item(), "foo") // Last element should also be "foo"
+	test.Equal(t, last.Item(), "foo", test.Context("Last element should also be \"foo\""))
 
 	// Prepend again
 	list.Prepend("bar")
@@ -97,11 +97,11 @@ func TestPrepend(t *testing.T) {
 
 	first, err = list.First()
 	test.Ok(t, err)
-	test.Equal(t, first.Item(), "bar") // First should now be "bar"
+	test.Equal(t, first.Item(), "bar", test.Context("First should now be \"bar\""))
 
 	last, err = list.Last()
 	test.Ok(t, err)
-	test.Equal(t, last.Item(), "foo") // Last should still be "foo"
+	test.Equal(t, last.Item(), "foo", test.Context("Last should still be \"foo\""))
 
 	// One more time
 	list.Prepend("baz")
@@ -109,11 +109,11 @@ func TestPrepend(t *testing.T) {
 
 	first, err = list.First()
 	test.Ok(t, err)
-	test.Equal(t, first.Item(), "baz") // First should now be "baz"
+	test.Equal(t, first.Item(), "baz", test.Context("First should now be \"baz\""))
 
 	last, err = list.Last()
 	test.Ok(t, err)
-	test.Equal(t, last.Item(), "foo") // Last should still be "foo"
+	test.Equal(t, last.Item(), "foo", test.Context("Last should still be \"foo\""))
 }
 
 func TestPop(t *testing.T) {
@@ -135,7 +135,7 @@ func TestPop(t *testing.T) {
 	three, err := list.Pop()
 	test.Ok(t, err)
 	test.Equal(t, three.Item(), 3)
-	test.Equal(t, list.Len(), 2) // Len should be 2 after Pop
+	test.Equal(t, list.Len(), 2, test.Context("Len should be 2 after Pop"))
 
 	last, err = list.Last()
 	test.Ok(t, err)
@@ -144,12 +144,12 @@ func TestPop(t *testing.T) {
 	two, err := list.Pop()
 	test.Ok(t, err)
 	test.Equal(t, two.Item(), 2)
-	test.Equal(t, list.Len(), 1) // Len should be 1 after second Pop
+	test.Equal(t, list.Len(), 1, test.Context("Len should be 1 after second Pop"))
 
 	one, err := list.Pop()
 	test.Ok(t, err)
 	test.Equal(t, one.Item(), 1)
-	test.Equal(t, list.Len(), 0) // Len should be 0 after third Pop
+	test.Equal(t, list.Len(), 0, test.Context("Len should be 0 after third Pop"))
 
 	first, err = list.First()
 	test.Err(t, err)
@@ -184,7 +184,7 @@ func TestPopFirst(t *testing.T) {
 	one, err := list.PopFirst()
 	test.Ok(t, err)
 	test.Equal(t, one.Item(), 1)
-	test.Equal(t, list.Len(), 2) // Len should be 2 after PopFirst
+	test.Equal(t, list.Len(), 2, test.Context("Len should be 2 after PopFirst"))
 
 	last, err = list.Last()
 	test.Ok(t, err)
@@ -193,12 +193,12 @@ func TestPopFirst(t *testing.T) {
 	two, err := list.PopFirst()
 	test.Ok(t, err)
 	test.Equal(t, two.Item(), 2)
-	test.Equal(t, list.Len(), 1) // Len should be 1 after second PopFirst
+	test.Equal(t, list.Len(), 1, test.Context("Len should be 1 after second PopFirst"))
 
 	three, err := list.PopFirst()
 	test.Ok(t, err)
 	test.Equal(t, three.Item(), 3)
-	test.Equal(t, list.Len(), 0) // Len should be 0 after third PopFirst
+	test.Equal(t, list.Len(), 0, test.Context("Len should be 0 after third PopFirst"))
 
 	first, err = list.First()
 	test.Err(t, err)

--- a/orderedmap/map_test.go
+++ b/orderedmap/map_test.go
@@ -41,6 +41,22 @@ func TestGetInsert(t *testing.T) {
 	test.Equal(t, val, "other item", test.Context("The new value should be returned from Get"))
 }
 
+func TestInsertRemove(t *testing.T) {
+	m := orderedmap.New[int, string]()
+
+	test.Equal(t, m.Size(), 0, test.Context("Wrong initial size"))
+
+	m.Insert(1, "one")
+
+	test.Equal(t, m.Size(), 1, test.Context("Wrong size after inserts"))
+
+	one, existed := m.Remove(1)
+	test.True(t, existed, test.Context("1 should have existed in the map"))
+	test.Equal(t, one, "one", test.Context("Wrong value returned from Remove"))
+
+	test.Equal(t, m.Size(), 0, test.Context("Wrong size after removal"))
+}
+
 func TestRemove(t *testing.T) {
 	m := orderedmap.New[int, string]()
 

--- a/orderedmap/map_test.go
+++ b/orderedmap/map_test.go
@@ -14,53 +14,53 @@ import (
 func TestGetInsert(t *testing.T) {
 	m := orderedmap.New[string, string]()
 
-	test.Equal(t, m.Size(), 0) // Starting size should be 0
+	test.Equal(t, m.Size(), 0, test.Context("Starting size should be 0"))
 
 	missing, ok := m.Get("missing")
-	test.False(t, ok)          // Missing item should return ok = false
-	test.Equal(t, missing, "") // Value should be zero value
+	test.False(t, ok, test.Context("Missing item should return ok = false"))
+	test.Equal(t, missing, "", test.Context("Value should be zero value"))
 
 	val, existed := m.Insert("new", "item")
-	test.False(t, existed)     // Insert of a new item should return false
-	test.Equal(t, val, "item") // Insert of new item should return item
+	test.False(t, existed, test.Context("Insert of a new item should return false"))
+	test.Equal(t, val, "item", test.Context("Insert of new item should return item"))
 
-	test.Equal(t, m.Size(), 1) // Wrong size, should contain 1 new item
+	test.Equal(t, m.Size(), 1, test.Context("Wrong size, should contain 1 new item"))
 
 	item, ok := m.Get("new")
-	test.True(t, ok)            // new should exist in the map
-	test.Equal(t, item, "item") // Retrieved item should be "item"
+	test.True(t, ok)
+	test.Equal(t, item, "item", test.Context("Retrieved item should be \"item\""))
 
 	old, existed := m.Insert("new", "other item")
-	test.True(t, existed)      // Item should have existed
-	test.Equal(t, old, "item") // Old item should be item
+	test.True(t, existed, test.Context("Item should have existed"))
+	test.Equal(t, old, "item", test.Context("Old item should be item"))
 
-	test.Equal(t, m.Size(), 1) // Wrong size, should contain 2 new items
+	test.Equal(t, m.Size(), 1, test.Context("Wrong size, should contain 2 new items"))
 
 	val, ok = m.Get("new")
-	test.True(t, ok)                 // Item should have existed
-	test.Equal(t, val, "other item") // The new value should be returned from Get
+	test.True(t, ok, test.Context("Item should have existed"))
+	test.Equal(t, val, "other item", test.Context("The new value should be returned from Get"))
 }
 
 func TestRemove(t *testing.T) {
 	m := orderedmap.New[int, string]()
 
-	test.Equal(t, m.Size(), 0) // Wrong initial size
+	test.Equal(t, m.Size(), 0, test.Context("Wrong initial size"))
 
 	missing, existed := m.Remove(42)
-	test.False(t, existed)     // existed should be false
-	test.Equal(t, missing, "") // should be zero value
+	test.False(t, existed, test.Context("existed should be false"))
+	test.Equal(t, missing, "", test.Context("should be zero value"))
 
 	m.Insert(1, "one")
 	m.Insert(2, "two")
 	m.Insert(3, "three")
 
-	test.Equal(t, m.Size(), 3) // Wrong size after inserts
+	test.Equal(t, m.Size(), 3, test.Context("Wrong size after inserts"))
 
 	two, existed := m.Remove(2)
-	test.True(t, existed)     // 2 should have existed in the map
-	test.Equal(t, two, "two") // Wrong value returned from Remove
+	test.True(t, existed, test.Context("2 should have existed in the map"))
+	test.Equal(t, two, "two", test.Context("Wrong value returned from Remove"))
 
-	test.Equal(t, m.Size(), 2) // Wrong size after removal
+	test.Equal(t, m.Size(), 2, test.Context("Wrong size after removal"))
 }
 
 func TestOldest(t *testing.T) {
@@ -79,8 +79,8 @@ func TestOldest(t *testing.T) {
 
 	oldestKey, oldestValue, ok = m.Oldest()
 	test.True(t, ok)
-	test.Equal(t, oldestKey, 1)       // Wrong oldest key
-	test.Equal(t, oldestValue, "one") // Wrong oldest value
+	test.Equal(t, oldestKey, 1, test.Context("Wrong oldest key"))
+	test.Equal(t, oldestValue, "one", test.Context("Wrong oldest value"))
 }
 
 func TestNewest(t *testing.T) {
@@ -99,26 +99,26 @@ func TestNewest(t *testing.T) {
 
 	newestKey, newestValue, ok = m.Newest()
 	test.True(t, ok)
-	test.Equal(t, newestKey, 4)        // Wrong newest key
-	test.Equal(t, newestValue, "four") // Wrong newest value
+	test.Equal(t, newestKey, 4, test.Context("Wrong newest key"))
+	test.Equal(t, newestValue, "four", test.Context("Wrong newest value"))
 }
 
 func TestGetOrInsert(t *testing.T) {
 	m := orderedmap.New[string, int]()
 
 	one, existed := m.GetOrInsert("one", 1)
-	test.False(t, existed) // should not have existed
-	test.Equal(t, one, 1)  // wrong value
+	test.False(t, existed, test.Context("should not have existed"))
+	test.Equal(t, one, 1, test.Context("wrong value"))
 
 	// Try again with same value
 	one, existed = m.GetOrInsert("one", 1)
-	test.True(t, existed) // should have existed this time
+	test.True(t, existed, test.Context("should have existed this time"))
 	test.Equal(t, one, 1)
 
 	// And again with different value
 	one, existed = m.GetOrInsert("one", 100)
-	test.True(t, existed) // should also exist
-	test.Equal(t, one, 1) // wrong value
+	test.True(t, existed, test.Context("should also exist"))
+	test.Equal(t, one, 1, test.Context("wrong value"))
 }
 
 func TestContains(t *testing.T) {
@@ -127,8 +127,8 @@ func TestContains(t *testing.T) {
 	m.Insert("two", 2)
 	m.Insert("three", 3)
 
-	test.True(t, m.Contains("one"))   // Map should contain "one"
-	test.False(t, m.Contains("four")) // "four" is not in the map
+	test.True(t, m.Contains("one"), test.Context("Map should contain \"one\""))
+	test.False(t, m.Contains("four"), test.Context("\"four\" is not in the map"))
 }
 
 func TestItems(t *testing.T) {

--- a/priority/queue_test.go
+++ b/priority/queue_test.go
@@ -9,11 +9,11 @@ import (
 
 func TestNew(t *testing.T) {
 	q := priority.New[string]()
-	test.Equal(t, q.Size(), 0)       // Initial size should be empty
-	test.Equal(t, q.IsEmpty(), true) // Should be empty
+	test.Equal(t, q.Size(), 0, test.Context("Initial size should be empty"))
+	test.Equal(t, q.IsEmpty(), true, test.Context("Should be empty"))
 
 	item, err := q.Pop()
-	test.Err(t, err) // Pop from empty queue
+	test.Err(t, err, test.Context("Pop from empty queue"))
 	test.Equal(t, item, "")
 }
 
@@ -69,16 +69,16 @@ func TestFromFunc(t *testing.T) {
 
 func TestSize(t *testing.T) {
 	q := priority.New[string]()
-	test.Equal(t, q.Size(), 0)       // Initial size should be empty
-	test.Equal(t, q.IsEmpty(), true) // Should be empty
+	test.Equal(t, q.Size(), 0, test.Context("Initial size should be empty"))
+	test.Equal(t, q.IsEmpty(), true, test.Context("Should be empty"))
 
 	q.Push("one", 1)
 	q.Push("two", 2)
 	q.Push("three", 3)
 	q.Push("four", 4)
 
-	test.Equal(t, q.Size(), 4)        // Wrong size after push
-	test.Equal(t, q.IsEmpty(), false) // Should not be empty
+	test.Equal(t, q.Size(), 4, test.Context("Wrong size after push"))
+	test.Equal(t, q.IsEmpty(), false, test.Context("Should not be empty"))
 }
 
 func TestPushPop(t *testing.T) {
@@ -89,28 +89,28 @@ func TestPushPop(t *testing.T) {
 	q.Push("three", 3)
 	q.Push("four", 4)
 
-	test.Equal(t, q.Size(), 4) // Incorrect size after push
+	test.Equal(t, q.Size(), 4, test.Context("Incorrect size after push"))
 
 	first, err := q.Pop()
 	test.Ok(t, err)
-	test.Equal(t, first, "four") // four has highest priority
+	test.Equal(t, first, "four", test.Context("four has highest priority"))
 
-	test.Equal(t, q.Size(), 3) // Incorrect size after pop
+	test.Equal(t, q.Size(), 3, test.Context("Incorrect size after pop"))
 
 	second, err := q.Pop()
 	test.Ok(t, err)
-	test.Equal(t, second, "three") // Next priority is in three
+	test.Equal(t, second, "three", test.Context("Next priority is in three"))
 
 	third, err := q.Pop()
 	test.Ok(t, err)
-	test.Equal(t, third, "two") // Next highest is two
+	test.Equal(t, third, "two", test.Context("Next highest is two"))
 
 	fourth, err := q.Pop()
 	test.Ok(t, err)
-	test.Equal(t, fourth, "one") // One is least
+	test.Equal(t, fourth, "one", test.Context("One is least"))
 
 	fifth, err := q.Pop()
-	test.Err(t, err) // Pop from empty queue
+	test.Err(t, err, test.Context("Pop from empty queue"))
 	test.Equal(t, fifth, "")
 }
 

--- a/set/set_test.go
+++ b/set/set_test.go
@@ -14,12 +14,12 @@ func TestInsert(t *testing.T) {
 	t.Run("strings", func(t *testing.T) {
 		s := set.New[string]()
 
-		test.True(t, s.IsEmpty()) // Initial set was not empty
+		test.True(t, s.IsEmpty(), test.Context("Initial set was not empty"))
 
-		test.True(t, s.Insert("foo"))    // Inserting foo for the first time should return true
-		test.False(t, s.Insert("foo"))   // Second insert of foo should return false
-		test.True(t, s.Contains("foo"))  // Set didn't contain "foo"
-		test.False(t, s.Contains("bar")) // Set said it contained "bar" but shouldn't have
+		test.True(t, s.Insert("foo"), test.Context("Inserting foo for the first time should return true"))
+		test.False(t, s.Insert("foo"), test.Context("Second insert of foo should return false"))
+		test.True(t, s.Contains("foo"), test.Context("Set didn't contain \"foo\""))
+		test.False(t, s.Contains("bar"), test.Context("Set said it contained \"bar\" but shouldn't have"))
 
 		// testing nil safety
 		danger := &set.Set[string]{}
@@ -30,10 +30,10 @@ func TestInsert(t *testing.T) {
 	t.Run("ints", func(t *testing.T) {
 		s := set.New[int]()
 
-		test.True(t, s.Insert(1))    // Inserting 1 for the first time should return true
-		test.False(t, s.Insert(1))   // Second insert of 1 should return false
-		test.True(t, s.Contains(1))  // Set didn't contain 1
-		test.False(t, s.Contains(2)) // Set said it contained 2 but shouldn't have
+		test.True(t, s.Insert(1), test.Context("Inserting 1 for the first time should return true"))
+		test.False(t, s.Insert(1), test.Context("Second insert of 1 should return false"))
+		test.True(t, s.Contains(1), test.Context("Set didn't contain 1"))
+		test.False(t, s.Contains(2), test.Context("Set said it contained 2 but shouldn't have"))
 
 		// testing nil safety
 		danger := &set.Set[int]{}
@@ -49,10 +49,10 @@ func TestFrom(t *testing.T) {
 		items := []string{"foo", "bar", "baz"}
 		other := set.From(items)
 
-		test.True(t, other.Contains("foo"))      // Set from items didn't contain "foo"
-		test.True(t, other.Contains("bar"))      // Set from items didn't contain "bar"
-		test.True(t, other.Contains("baz"))      // Set from items didn't contain "baz"
-		test.False(t, other.Contains("missing")) // Missing item "missing" reported as present
+		test.True(t, other.Contains("foo"), test.Context("Set from items didn't contain \"foo\""))
+		test.True(t, other.Contains("bar"), test.Context("Set from items didn't contain \"bar\""))
+		test.True(t, other.Contains("baz"), test.Context("Set from items didn't contain \"baz\""))
+		test.False(t, other.Contains("missing"), test.Context("Missing item \"missing\" reported as present"))
 	})
 
 	t.Run("floats", func(t *testing.T) {
@@ -60,10 +60,10 @@ func TestFrom(t *testing.T) {
 		items := []float64{3.14159, 42.58, 69.73}
 		other := set.From(items)
 
-		test.True(t, other.Contains(3.14159)) // Set from items didn't contain pi
-		test.True(t, other.Contains(42.58))   // Set from items didn't contain 42.58
-		test.True(t, other.Contains(69.73))   // Set from items didn't contain 69.73
-		test.False(t, other.Contains(100.1))  // Missing item 100.1 reported as present
+		test.True(t, other.Contains(3.14159), test.Context("Set from items didn't contain pi"))
+		test.True(t, other.Contains(42.58), test.Context("Set from items didn't contain 42.58"))
+		test.True(t, other.Contains(69.73), test.Context("Set from items didn't contain 69.73"))
+		test.False(t, other.Contains(100.1), test.Context("Missing item 100.1 reported as present"))
 	})
 }
 
@@ -89,13 +89,13 @@ func TestRemove(t *testing.T) {
 		set.Insert(gandalf)
 		set.Insert(wendy)
 
-		test.Equal(t, set.Size(), 3) // Incorrect size
+		test.Equal(t, set.Size(), 3, test.Context("Incorrect size"))
 
 		// Sorry Wendy
 		removed := set.Remove(wendy)
-		test.True(t, removed) // Removed should be true
+		test.True(t, removed, test.Context("Removed should be true"))
 
-		test.Equal(t, set.Size(), 2) // Incorrect size after killing wendy
+		test.Equal(t, set.Size(), 2, test.Context("Incorrect size after killing wendy"))
 
 		test.False(t, set.Contains(wendy))
 	})

--- a/stack/stack_test.go
+++ b/stack/stack_test.go
@@ -20,7 +20,7 @@ func TestIsEmpty(t *testing.T) {
 	s.Push("general")
 	s.Push("kenobi")
 
-	test.False(t, s.IsEmpty()) // Empty should not be false
+	test.False(t, s.IsEmpty(), test.Context("Empty should not be false"))
 }
 
 func TestPop(t *testing.T) {
@@ -48,8 +48,8 @@ func TestPop(t *testing.T) {
 
 	// Try one more pop, should error
 	item, err = s.Pop()
-	test.Err(t, err)        // Pop from empty stack should error
-	test.Equal(t, item, "") // Item should be the zero value
+	test.Err(t, err, test.Context("Pop from empty stack should error"))
+	test.Equal(t, item, "", test.Context("Item should be the zero value"))
 }
 
 func TestNotNew(t *testing.T) {


### PR DESCRIPTION
- **Port old comment style test context to use `test.Context`**
- **Add ordered-map regression in LL insert bug**

# Summary
<!-- Describe your changes in detail here, if it closes an open issue, include "Closes #<issue>" -->
