### PR TITLE
Fix a bug in `stack` where the popped element was not zeroed in the backing array

### DIFF
--- a/stack/stack.go
+++ b/stack/stack.go
@@ -80,6 +80,8 @@ func (s *Stack[T]) Pop() (T, error) {
 	}
 
 	item := s.container[l-1]
+	var zero T
+	s.container[l-1] = zero // for GC, otherwise this element might still be reachable
 	s.container = s.container[:l-1]
 
 	return item, nil


### PR DESCRIPTION
# Summary
<!-- Describe your changes in detail here, if it closes an open issue, include "Closes #<issue>" -->
